### PR TITLE
Make libavif-{image,sys} workspace members of libavif

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ libavif-sys={version="0.4",path= "libavif-sys" }
 [dev-dependencies]
 image="0.23"
 
+[workspace]
+members = [
+  "libavif-image",
+  "libavif-sys"
+]


### PR DESCRIPTION
First of all, thanks for making this. I'm also interested in working with libavif in Rust and your crates made it so I won't have to do everything from scratch.

This PR makes libavif-image and libavif-sys [workspace members](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) of libavif