### PR TITLE
Disable default features for the image crate

### DIFF
--- a/libavif-image/Cargo.toml
+++ b/libavif-image/Cargo.toml
@@ -13,5 +13,5 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-image="0.23"
-libavif={version="0.1", path=".."}
+image = { version = "0.23", default-features = false }
+libavif = { version = "0.1", path=".." }


### PR DESCRIPTION
This will allow top level crates to depend only on a subset of features from the image crate