### PR TITLE
Allow changing codec from libavif and libavif-image | Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,16 @@ license="BSD-2-Clause"
 readme = "README.md"
 
 [dependencies]
-libavif-sys={version="0.4",path= "libavif-sys" }
+libavif-sys = { version = "0.4", path = "libavif-sys", default-features = false }
 
 [dev-dependencies]
-image="0.23"
+image = "0.23"
+
+[features]
+default = ["codec-dav1d", "codec-rav1e"]
+codec-rav1e = ["libavif-sys/codec-rav1e"]
+codec-dav1d = ["libavif-sys/codec-dav1d"]
+codec-aom = ["libavif-sys/codec-aom"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ codec-rav1e = ["libavif-sys/codec-rav1e"]
 codec-dav1d = ["libavif-sys/codec-dav1d"]
 codec-aom = ["libavif-sys/codec-aom"]
 
+__internal_aom_generic_target = ["libavif-sys/__internal_aom_generic_target"]
+
+[package.metadata.docs.rs]
+no-default-features = true
+features = ["codec-aom", "__internal_aom_generic_target"]
+
 [workspace]
 members = [
   "libavif-image",

--- a/libavif-image/Cargo.toml
+++ b/libavif-image/Cargo.toml
@@ -21,3 +21,9 @@ default = ["codec-dav1d", "codec-rav1e"]
 codec-rav1e = ["libavif/codec-rav1e"]
 codec-dav1d = ["libavif/codec-dav1d"]
 codec-aom = ["libavif/codec-aom"]
+
+__internal_aom_generic_target = ["libavif/__internal_aom_generic_target"]
+
+[package.metadata.docs.rs]
+no-default-features = true
+features = ["codec-aom", "__internal_aom_generic_target"]

--- a/libavif-image/Cargo.toml
+++ b/libavif-image/Cargo.toml
@@ -14,4 +14,10 @@ readme = "README.md"
 
 [dependencies]
 image = { version = "0.23", default-features = false }
-libavif = { version = "0.1", path=".." }
+libavif = { version = "0.1", path = "..", default-features = false }
+
+[features]
+default = ["codec-dav1d", "codec-rav1e"]
+codec-rav1e = ["libavif/codec-rav1e"]
+codec-dav1d = ["libavif/codec-dav1d"]
+codec-aom = ["libavif/codec-aom"]

--- a/libavif-sys/Cargo.toml
+++ b/libavif-sys/Cargo.toml
@@ -17,9 +17,15 @@ codec-rav1e = ["rav1e"]
 codec-dav1d = []
 codec-aom = []
 
+__internal_aom_generic_target = []
+
 [dependencies]
 libc = "0.2"
 rav1e = { version = "0.3", features = ["asm", "capi"], optional = true }
 
 [build-dependencies]
 cmake = "0.1"
+
+[package.metadata.docs.rs]
+no-default-features = true
+features = ["codec-aom", "__internal_aom_generic_target"]

--- a/libavif-sys/build.rs
+++ b/libavif-sys/build.rs
@@ -13,16 +13,20 @@ fn main() {
         eprintln!("building aom");
         // let aom = "/home/charles/dev/libavif/target/release/build/libavif-sys-e65a2afd78d3a783/out/build";
 
-        let aom = Config::new("aom")
-            .define("ENABLE_DOCS", "0")
+        let mut aom = Config::new("aom");
+        aom.define("ENABLE_DOCS", "0")
             .define("ENABLE_EXAMPLES", "0")
             .define("ENABLE_TESTDATA", "0")
             .define("ENABLE_TESTS", "0")
-            .define("ENABLE_TOOLS", "0")
-            .profile("Release")
-            .build();
+            .define("ENABLE_TOOLS", "0");
 
-        eprintln!("built aom: {:?}", aom);
+        #[cfg(feature = "__internal_aom_generic_target")]
+        {
+            aom.define("AOM_TARGET_CPU", "generic");
+        }
+
+        aom.profile("Release").build();
+
         avif.define("AVIF_CODEC_AOM", "1");
         println!("cargo:rustc-link-lib=static=aom");
     }


### PR DESCRIPTION
This allows changing libavif-sys features from libavif and libavif-image, which wasn't possible before since libavif imported libavif-sys with default features enabled.

This change should also [fix builds on docs.rs](https://docs.rs/crate/libavif-sys/0.4.0/builds/222959) by compiling using aom, since the dependencies necessary to build dav1d aren't available there. I added an hidden feature named `__internal_aom_generic_target`, telling aom to compile without cpu target optimizations, since nasm is also missing from the docs.rs build environment.